### PR TITLE
Adapt Python scripts to ElastiCluster's new configuration API.

### DIFF
--- a/bin/cluster_util.py
+++ b/bin/cluster_util.py
@@ -19,6 +19,8 @@
 # Utility routines for managing an Elasticluster cluster.
 
 import elasticluster
+import elasticluster.conf
+from elasticluster.__main__ import ElastiCluster
 
 import json
 import subprocess
@@ -51,10 +53,10 @@ def get_zone_for_cluster(cluster_name):
   with the cluster. So we will pull it from the existing configuration
   (we assume the cluster configuration has not been changed)."""
 
-  configurator = elasticluster.get_configurator()
+  creator = elasticluster.conf.make_creator(ElastiCluster.default_configuration_file)
 
-  # Assume the template name is the same as the cluster_name
-  conf = configurator.cluster_conf[cluster_name]
+  # FIXME: should not assume the template name is the same as the cluster_name
+  conf = creator.cluster_conf[cluster_name]
   return conf['cloud']['zone']
 
 
@@ -127,10 +129,10 @@ def get_desired_cluster_nodes(cluster_name):
 
   nodes = {}
 
-  configurator = elasticluster.get_configurator()
+  creator = elasticluster.conf.make_creator(ElastiCluster.default_configuration_file)
 
-  # Assume the template name is the same as the cluster_name
-  conf = configurator.cluster_conf[cluster_name]
+  # FIXME: should not assume the template name is the same as the cluster_name
+  conf = creator.cluster_conf[cluster_name]
   for key in conf['cluster']:
     if key.endswith('_nodes'):
       kind = key[:-len('_nodes')]

--- a/bin/cluster_util.py
+++ b/bin/cluster_util.py
@@ -133,10 +133,10 @@ def get_desired_cluster_nodes(cluster_name):
 
   # FIXME: should not assume the template name is the same as the cluster_name
   conf = creator.cluster_conf[cluster_name]
-  for key in conf['cluster']:
+  for key in conf:
     if key.endswith('_nodes'):
       kind = key[:-len('_nodes')]
-      nodes[kind] = int(conf['cluster'][key])
+      nodes[kind] = int(conf[key])
 
   return nodes
 

--- a/bin/ensure_cluster_size.py
+++ b/bin/ensure_cluster_size.py
@@ -21,6 +21,9 @@
 # the cluster configuration.
 
 import elasticluster
+import elasticluster.conf
+from elasticluster.__main__ import ElastiCluster
+
 import cluster_util
 
 import os
@@ -43,10 +46,10 @@ dryrun=os.environ['DRYRUN'] if 'DRYRUN' in os.environ else None
 # BEGIN MAIN
 
 # Create the elasticluster configuration endpoint
-configurator = elasticluster.get_configurator()
+creator = elasticluster.conf.make_creator(ElastiCluster.default_configuration_file)
 
 # Lookup the cluster
-cluster = configurator.load_cluster(cluster_name)
+cluster = creator.load_cluster(cluster_name)
 cluster.update()
 
 print "*********************"

--- a/bin/list_all_instances.py
+++ b/bin/list_all_instances.py
@@ -20,6 +20,9 @@
 # for a cluster. The "node type" can optionally be specified.
 
 import elasticluster
+import elasticluster.conf
+from elasticluster.__main__ import ElastiCluster
+
 
 import sys
 
@@ -32,10 +35,10 @@ cluster_name=sys.argv[1]
 node_type=sys.argv[2] if len(sys.argv) > 2 else None
 
 # Create the elasticluster configuration endpoint
-configurator = elasticluster.get_configurator()
+creator = elasticluster.conf.make_creator(ElastiCluster.default_configuration_file)
 
 # Lookup the cluster
-cluster = configurator.load_cluster(cluster_name)
+cluster = creator.load_cluster(cluster_name)
 
 # Emit the node names
 for node in cluster.get_all_nodes():

--- a/bin/list_all_nodes.py
+++ b/bin/list_all_nodes.py
@@ -20,6 +20,9 @@
 # for a cluster. The "node type" can optionally be specified.
 
 import elasticluster
+import elasticluster.conf
+from elasticluster.__main__ import ElastiCluster
+
 
 import sys
 
@@ -32,10 +35,10 @@ cluster_name=sys.argv[1]
 node_type=sys.argv[2] if len(sys.argv) > 2 else None
 
 # Create the elasticluster configuration endpoint
-configurator = elasticluster.get_configurator()
+creator = elasticluster.conf.make_creator(ElastiCluster.default_configuration_file)
 
 # Lookup the cluster
-cluster = configurator.load_cluster(cluster_name)
+cluster = creator.load_cluster(cluster_name)
 
 # Emit the node names
 for node in cluster.get_all_nodes():

--- a/bin/remove_terminated_nodes.py
+++ b/bin/remove_terminated_nodes.py
@@ -20,6 +20,9 @@
 # in a TERMINATED, STOPPING, or unknown state.
 
 import elasticluster
+import elasticluster.conf
+from elasticluster.__main__ import ElastiCluster
+
 import cluster_util
 
 import errno
@@ -50,10 +53,10 @@ known_hosts_file = '%s/%s' % (
   os.environ['HOME'], '.elasticluster/storage/%s.known_hosts' % cluster_name)
 
 # Create the elasticluster configuration endpoint
-configurator = elasticluster.get_configurator()
+creator = elasticluster.conf.make_creator(ElastiCluster.default_configuration_file)
 
 # Lookup the cluster
-cluster = configurator.load_cluster(cluster_name)
+cluster = creator.load_cluster(cluster_name)
 cluster.update()
 
 # Build a list of nodes to remove

--- a/bin/sanitize_known_hosts.py
+++ b/bin/sanitize_known_hosts.py
@@ -20,6 +20,9 @@
 # the known_hosts file with only those members.
 
 import elasticluster
+import elasticluster.conf
+from elasticluster.__main__ import ElastiCluster
+
 import paramiko
 
 import sys
@@ -32,10 +35,10 @@ if len(sys.argv) != 2:
 cluster_name=sys.argv[1]
 
 # Create the elasticluster configuration endpoint
-configurator = elasticluster.get_configurator()
+creator = elasticluster.conf.make_creator(ElastiCluster.default_configuration_file)
 
 # Lookup the cluster
-cluster = configurator.load_cluster(cluster_name)
+cluster = creator.load_cluster(cluster_name)
 
 # Get the list of IP addresses
 ip_addrs = [node.preferred_ip for node in cluster.get_all_nodes()]


### PR DESCRIPTION
The `elasticlusterget_configurator()` helper method was replaced with
`elasticluster.conf.make_creator()` (with a slightly different interface) during
the ElastiCluster configuration overhaul.

This commit changes the code to use the new interface.